### PR TITLE
Add error event listeners on all metric streams

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -78,8 +78,12 @@ const PodiumProxy = class PodiumProxy {
             value: pathRegex(regExPath, this.pathnameEntries),
         });
 
+        this.metrics.on('error', error => {
+            this.log.error('Error emitted by metric stream in @podium/proxy module', error);
+        });
+
         this.proxy.on('error', error => {
-            this.log.error(error);
+            this.log.error('Error emitted by proxy in @podium/proxy module', error);
         });
 
         this.proxy.on('proxyReq', (proxyReq, req, res) => {

--- a/package.json
+++ b/package.json
@@ -40,14 +40,14 @@
         "ttl-mem-cache": "4.0.2"
     },
     "devDependencies": {
-        "eslint": "^5.14.1",
+        "eslint": "^5.15.0",
         "eslint-config-airbnb-base": "^13.1.0",
-        "eslint-config-prettier": "^4.0.0",
+        "eslint-config-prettier": "^4.1.0",
         "eslint-plugin-import": "^2.14.0",
         "eslint-plugin-prettier": "^3.0.0",
         "jest": "^24.1.0",
         "prettier": "^1.14.2",
-        "readable-stream": "^3.1.1"
+        "readable-stream": "^3.2.0"
     },
     "jest": {
         "coveragePathIgnorePatterns": [


### PR DESCRIPTION
This adds error event listeners on the metric stream. Guards against errors in the stream.