### PR TITLE
Listen for error events on the internal cache

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -50,6 +50,10 @@ const PodiumProxy = class PodiumProxy {
             }),
         });
 
+        this.registry.on('error', error => {
+            this.log.error('Error emitted by the registry in @podium/proxy module', error);
+        });
+
         Object.defineProperty(this, 'proxy', {
             // eslint-disable-next-line new-cap
             value: new Proxy.createProxy({


### PR DESCRIPTION
The internal cache is a stream which we use to exchange manifest data between the client and the proxy. Listen for `error` events on this stream.