### PR TITLE
Use the HttpIncoming.proxy property to flag the request

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,13 @@ the target.
 Metod for processing a incoming HTTP request. Matches the request against the
 registered routing targets and proxies the request if a match is found.
 
-Returns a promise. If the inbound request matches a proxy endpoint the returned
-Promise will resolve with `undefined`. If the inbound request does not match a
-proxy endpoint the returned promise will resolve with the passed in
-[HttpIncoming] object.
+Returns a promise. When resolving the passed in [HttpIncoming] object will be
+returned.
+
+If the inbound request matches a proxy endpoint and a proxy request was
+successfully performed, the `.proxy` property on the returned [HttpIncoming]
+object will be `true`. If the inbound request did not yeld a proxy request, the
+`.proxy` property on the returned [HttpIncoming]  object will be `false`.
 
 The method takes the following arguments:
 
@@ -144,10 +147,10 @@ const app = http.createServer(async (req, res) => {
     const incoming = new HttpIncoming(req, res);
     const result = await proxy.process(incoming);
 
-    if (!result) {
-        res.statusCode = 404;
-        res.end('404 - Not found');
-    }
+    if (result.proxy) return;
+
+    res.statusCode = 404;
+    res.end('404 - Not found');
 });
 ```
 

--- a/__tests__/proxying.js
+++ b/__tests__/proxying.js
@@ -101,17 +101,16 @@ class ProxyServer {
             this.proxy
                 .process(incoming)
                 .then(result => {
-                    if (result) {
-                        res.statusCode = 200;
-                        res.setHeader('Content-Type', 'application/json');
-                        res.end(
-                            JSON.stringify({
-                                message: 'ok',
-                                status: 200,
-                                type: 'proxy',
-                            }),
-                        );
-                    }
+                    if (result.proxy) return;
+                    res.statusCode = 200;
+                    res.setHeader('Content-Type', 'application/json');
+                    res.end(
+                        JSON.stringify({
+                            message: 'ok',
+                            status: 200,
+                            type: 'proxy',
+                        }),
+                    );
                 })
                 .catch(() => {
                     res.statusCode = 404;

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -233,7 +233,8 @@ const PodiumProxy = class PodiumProxy {
                 };
 
                 incoming.response.on('finish', () => {
-                    resolve();
+                    incoming.proxy = true;
+                    resolve(incoming);
                 });
 
                 this.proxy.web(

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "dependencies": {
         "@metrics/client": "2.4.1",
         "@podium/schemas": "3.0.0",
-        "@podium/utils": "3.1.2",
+        "@podium/utils": "4.0.0-next",
         "abslog": "2.4.0",
         "http-proxy": "1.17.0",
         "joi": "14.3.1",


### PR DESCRIPTION
This uses the `.proxy` property on `HttpIncoming` (https://github.com/podium-lib/utils/pull/8) to flag if the request was a proxy request or not.