### PR TITLE
reinstrument proxy using latest metric syntax

### DIFF
--- a/__tests__/proxying.js
+++ b/__tests__/proxying.js
@@ -388,14 +388,24 @@ test('Proxying() - metrics collection', async done => {
 
     proxy.proxy.metrics.pipe(
         destObjectStream(arr => {
-            expect(arr).toHaveLength(2);
-            /*
-            TODO: Commented out due to the way we get this info is wrong
-            expect(arr[0].meta.podlet).toBe('foo');
-            expect(arr[0].meta.proxy).toBe('a');
-            expect(arr[1].meta.podlet).toBe('bar');
-            expect(arr[1].meta.proxy).toBe('a');
-            */
+            expect(arr).toHaveLength(3);
+            expect(arr[0].name).toBe('podium_proxy_process');
+            expect(arr[0].type).toBe(5);
+            expect(arr[0].labels).toEqual([
+                { name: 'podlet', value: null },
+                { name: 'proxy', value: false },
+                { name: 'error', value: false },
+            ]);
+            expect(arr[1].labels).toEqual([
+                { name: 'podlet', value: 'foo' },
+                { name: 'proxy', value: true },
+                { name: 'error', value: false },
+            ]);
+            expect(arr[2].labels).toEqual([
+                { name: 'podlet', value: 'bar' },
+                { name: 'proxy', value: true },
+                { name: 'error', value: false },
+            ]);
             done();
         }),
     );

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -50,7 +50,10 @@ const PodiumProxy = class PodiumProxy {
         });
 
         this.registry.on('error', error => {
-            this.log.error('Error emitted by the registry in @podium/proxy module', error);
+            this.log.error(
+                'Error emitted by the registry in @podium/proxy module',
+                error,
+            );
         });
 
         Object.defineProperty(this, 'proxy', {
@@ -82,31 +85,17 @@ const PodiumProxy = class PodiumProxy {
         });
 
         this.metrics.on('error', error => {
-            this.log.error('Error emitted by metric stream in @podium/proxy module', error);
+            this.log.error(
+                'Error emitted by metric stream in @podium/proxy module',
+                error,
+            );
         });
 
         this.proxy.on('error', error => {
-            this.log.error('Error emitted by proxy in @podium/proxy module', error);
-        });
-
-        this.proxy.on('proxyReq', (proxyReq, req, res) => {
-            const end = this.metrics.timer({
-                name: 'podium_proxy_request',
-                description:
-                    'Proxy requests through a layout to target determined by podlet manifest',
-                /*
-                TODO: we can not count like this due to not having res.locals
-                when stuff is framework free
-                meta: {
-                    podlet: res.locals.podlet,
-                    proxy: res.locals.proxy,
-                },
-                */
-            });
-
-            res.on('finish', () => {
-                end();
-            });
+            this.log.error(
+                'Error emitted by proxy in @podium/proxy module',
+                error,
+            );
         });
 
         this.registry.on('set', (key, item) => {
@@ -138,9 +127,10 @@ const PodiumProxy = class PodiumProxy {
         // Do a stringify to hande that a @podium/podlet instance is passed in.
         const obj = JSON.parse(JSON.stringify(manifest));
 
-        if (validate.manifest(obj).error) throw new Error(
-            'The value for the required argument "manifest" is not defined or not valid.'
-        );
+        if (validate.manifest(obj).error)
+            throw new Error(
+                'The value for the required argument "manifest" is not defined or not valid.',
+            );
 
         this.registry.set(obj.name, obj, Infinity);
     }
@@ -152,6 +142,17 @@ const PodiumProxy = class PodiumProxy {
         ) {
             throw TypeError('Argument must be of type "PodiumHttpIncoming"');
         }
+
+        const histogram = this.metrics.histogram({
+            name: 'podium_proxy_process',
+            description: 'Measures time spent in the proxy process method',
+            labels: {
+                podlet: null,
+                proxy: false,
+                error: false,
+            },
+        });
+        const endTimer = histogram.timer();
 
         return new Promise((resolve, reject) => {
             const match = this.pathnameParser.exec(incoming.url.pathname);
@@ -168,6 +169,7 @@ const PodiumProxy = class PodiumProxy {
                 // If so we might want to proxy. If not, skip rest of processing
                 const manifest = this.registry.get(params.podiumPodletName);
                 if (!manifest) {
+                    endTimer({ labels: { podlet: params.podiumPodletName } });
                     resolve(incoming);
                     return;
                 }
@@ -176,6 +178,7 @@ const PodiumProxy = class PodiumProxy {
                 // If so we want to proxy. If not, skip rest of processing
                 let target = manifest.proxy[params.podiumProxyName];
                 if (!target) {
+                    endTimer({ labels: { podlet: params.podiumPodletName } });
                     resolve(incoming);
                     return;
                 }
@@ -227,7 +230,14 @@ const PodiumProxy = class PodiumProxy {
                 };
 
                 incoming.response.on('finish', () => {
+                    // eslint-disable-next-line no-param-reassign
                     incoming.proxy = true;
+                    endTimer({
+                        labels: {
+                            podlet: params.podiumPodletName,
+                            proxy: true,
+                        },
+                    });
                     resolve(incoming);
                 });
 
@@ -236,12 +246,20 @@ const PodiumProxy = class PodiumProxy {
                     incoming.response,
                     config,
                     error => {
+                        endTimer({
+                            labels: {
+                                podlet: params.podiumPodletName,
+                                proxy: true,
+                                error: true,
+                            },
+                        });
                         reject(error);
                     },
                 );
 
                 return;
             }
+            endTimer();
             resolve(incoming);
         });
     }


### PR DESCRIPTION
* move metrics into process method
* measure all paths in process method using labels to flag paths
* update metric syntax using histogram method
* rename metric to podium metric conventions `podium_<lib>_<module/class>_method`