### PR TITLE
adds name label to metric

### DIFF
--- a/__tests__/proxying.js
+++ b/__tests__/proxying.js
@@ -392,16 +392,19 @@ test('Proxying() - metrics collection', async done => {
             expect(arr[0].name).toBe('podium_proxy_process');
             expect(arr[0].type).toBe(5);
             expect(arr[0].labels).toEqual([
+                { name: 'name', value: '' },
                 { name: 'podlet', value: null },
                 { name: 'proxy', value: false },
                 { name: 'error', value: false },
             ]);
             expect(arr[1].labels).toEqual([
+                { name: 'name', value: '' },
                 { name: 'podlet', value: 'foo' },
                 { name: 'proxy', value: true },
                 { name: 'error', value: false },
             ]);
             expect(arr[2].labels).toEqual([
+                { name: 'name', value: '' },
                 { name: 'podlet', value: 'bar' },
                 { name: 'proxy', value: true },
                 { name: 'error', value: false },

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -147,6 +147,7 @@ const PodiumProxy = class PodiumProxy {
             name: 'podium_proxy_process',
             description: 'Measures time spent in the proxy process method',
             labels: {
+                name: incoming.name,
                 podlet: null,
                 proxy: false,
                 error: false,


### PR DESCRIPTION
this will be layout name when proxy is used in a layout and podlet name
when proxy is used in a podlet though in practice, a proxy is only ever
mounted in a podlet during development so this value will always be the
layout name