### PR TITLE
Use @podium/test-utils for destination stream

### DIFF
--- a/__tests__/proxying.js
+++ b/__tests__/proxying.js
@@ -1,28 +1,11 @@
 'use strict';
 
-const http = require('http');
-const { URL } = require('url');
-const { Writable } = require('readable-stream');
+const { destinationObjectStream } = require('@podium/test-utils');
 const { HttpIncoming } = require('@podium/utils');
+const { URL } = require('url');
+const http = require('http');
+
 const Proxy = require('../');
-
-const destObjectStream = done => {
-    const arr = [];
-
-    const dStream = new Writable({
-        objectMode: true,
-        write(chunk, encoding, callback) {
-            arr.push(chunk);
-            callback();
-        },
-    });
-
-    dStream.on('finish', () => {
-        done(arr);
-    });
-
-    return dStream;
-};
 
 /**
  * Destination server utility
@@ -387,7 +370,7 @@ test('Proxying() - metrics collection', async done => {
     ]);
 
     proxy.proxy.metrics.pipe(
-        destObjectStream(arr => {
+        destinationObjectStream(arr => {
             expect(arr).toHaveLength(2);
             /*
             TODO: Commented out due to the way we get this info is wrong

--- a/package.json
+++ b/package.json
@@ -39,14 +39,14 @@
         "ttl-mem-cache": "4.1.0"
     },
     "devDependencies": {
+        "@podium/test-utils": "1.1.0",
         "eslint": "^5.15.3",
         "eslint-config-airbnb-base": "^13.1.0",
         "eslint-config-prettier": "^4.1.0",
         "eslint-plugin-import": "^2.14.0",
         "eslint-plugin-prettier": "^3.0.0",
         "jest": "^24.5.0",
-        "prettier": "^1.14.2",
-        "readable-stream": "^3.2.0"
+        "prettier": "^1.14.2"
     },
     "jest": {
         "coveragePathIgnorePatterns": [


### PR DESCRIPTION
Replaces the internal destination stream helper method with the one in @podium/test-utils.

