### PR TITLE
Make sure finish event is not emitted after error event

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -142,7 +142,7 @@ const PodiumProxy = class PodiumProxy {
         });
         const endTimer = histogram.timer();
 
-        const prom = new Promise((resolve, reject) => {
+        return new Promise((resolve, reject) => {
             const match = this.pathnameParser.exec(incoming.url.pathname);
             let errored = false;
 
@@ -256,8 +256,6 @@ const PodiumProxy = class PodiumProxy {
             endTimer();
             resolve(incoming);
         });
-
-        return prom;
     }
 
     dump() {

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -8,17 +8,6 @@ const abslog = require('abslog');
 const utils = require('@podium/utils');
 const Cache = require('ttl-mem-cache');
 const Proxy = require('http-proxy');
-// const http = require('http');
-
-/*
-const HTTP_AGENT = new http.Agent({
-    keepAlive: true,
-    maxSockets: 10,
-    maxFreeSockets: 10,
-    timeout: 60000,
-    keepAliveMsecs: 30000,
-});
-*/
 
 const PodiumProxy = class PodiumProxy {
     constructor({
@@ -26,7 +15,6 @@ const PodiumProxy = class PodiumProxy {
         prefix = '/podium-resource',
         timeout = 20000,
         maxAge = Infinity,
-        // agent = HTTP_AGENT,
         logger = null,
     } = {}) {
         Object.defineProperty(this, 'pathname', {
@@ -60,7 +48,6 @@ const PodiumProxy = class PodiumProxy {
             // eslint-disable-next-line new-cap
             value: new Proxy.createProxy({
                 proxyTimeout: timeout,
-                // agent: agent
             }),
         });
 
@@ -155,8 +142,9 @@ const PodiumProxy = class PodiumProxy {
         });
         const endTimer = histogram.timer();
 
-        return new Promise((resolve, reject) => {
+        const prom = new Promise((resolve, reject) => {
             const match = this.pathnameParser.exec(incoming.url.pathname);
+            let errored = false;
 
             if (match) {
                 // Turn matched uri parameters into an object of parameters
@@ -231,6 +219,10 @@ const PodiumProxy = class PodiumProxy {
                 };
 
                 incoming.response.on('finish', () => {
+                    // The finish event will be called after error, prevent
+                    // resolving and metrics being called after an error
+                    if (errored) return;
+
                     // eslint-disable-next-line no-param-reassign
                     incoming.proxy = true;
                     endTimer({
@@ -247,6 +239,7 @@ const PodiumProxy = class PodiumProxy {
                     incoming.response,
                     config,
                     error => {
+                        errored = true;
                         endTimer({
                             labels: {
                                 podlet: params.podiumPodletName,
@@ -263,6 +256,8 @@ const PodiumProxy = class PodiumProxy {
             endTimer();
             resolve(incoming);
         });
+
+        return prom;
     }
 
     dump() {


### PR DESCRIPTION
This fixes a bug where an erroring proxy request will cause both `error` and `finish` event to be emitted which again causes double metrics in these error cases. 

It also causes the promise to be resolved after its been rejected. Though; that does not cause any harm in it self.