### PR TITLE
fix incorrect name label definition

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -141,7 +141,9 @@ const PodiumProxy = class PodiumProxy {
         }
 
         const endTimer = this.histogram.timer({
-            name: incoming.name,
+            labels: {
+                name: incoming.name,
+            },
         });
 
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
Adds fix and test to verify fix works. Updated the Proxy Server mock to make it possible to set `name` on `HttpIncoming` to make this test possible.