### PR TITLE
Patch proxy trailer header vulnerability

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -151,17 +151,10 @@ const PodiumProxy = class PodiumProxy {
             let errored = false;
 
             if (match) {
-                // eslint-disable-next-line no-param-reassign
-                const { headers } = incoming.request;
-                if (headers.trailer) {
-                    if (
-                        !headers['transfer-encoding'] ||
-                        headers['transfer-encoding'].toLowerCase() !== 'chunked'
-                    ) {
-                        incoming.response.writeHead(400);
-                        incoming.response.end();
-                        return;
-                    }
+                if (incoming.request.headers.trailer) {
+                    incoming.response.writeHead(400);
+                    incoming.response.end();
+                    return;
                 }
 
                 // Turn matched uri parameters into an object of parameters

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -152,7 +152,17 @@ const PodiumProxy = class PodiumProxy {
 
             if (match) {
                 // eslint-disable-next-line no-param-reassign
-                delete incoming.request.headers.trailer;
+                const { headers } = incoming.request;
+                if (headers.trailer) {
+                    if (
+                        !headers['transfer-encoding'] ||
+                        headers['transfer-encoding'].toLowerCase() !== 'chunked'
+                    ) {
+                        incoming.response.writeHead(400);
+                        incoming.response.end();
+                        return;
+                    }
+                }
 
                 // Turn matched uri parameters into an object of parameters
                 const params = {};

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -151,6 +151,9 @@ const PodiumProxy = class PodiumProxy {
             let errored = false;
 
             if (match) {
+                // eslint-disable-next-line no-param-reassign
+                delete incoming.request.headers.trailer;
+
                 // Turn matched uri parameters into an object of parameters
                 const params = {};
                 for (let i = 1; i < match.length; i += 1) {

--- a/tests/proxying.js
+++ b/tests/proxying.js
@@ -444,7 +444,7 @@ test('Proxying() - proxy to a non existing server - GET request will error - sho
     t.end();
 });
 
-test('Proxying() - Trailer header - 400s when Transfer-Encoding is not present', async (t) => {
+test('Proxying() - Trailer header - 400s when Trailer header is present', async (t) => {
     const server = new HttpServer();
     server.request = reqFn;
     const serverAddr = await server.listen();
@@ -481,7 +481,7 @@ test('Proxying() - Trailer header - 400s when Transfer-Encoding is not present',
     t.match(
         stdout,
         '400 Bad Request',
-        'Omitting transfer-encoding header results in 400',
+        'Including Trailer header results in 400',
     );
 
     await proxy.close();


### PR DESCRIPTION
The Trailer header should not be forwarded by proxies and will crash the server if they are.
This PR detects the trailer header and responds with a 400 bad request if detected.

See: https://datatracker.ietf.org/doc/html/rfc2616#section-13.5.1