### PR TITLE
feat: Support manifest with array of proxy endpoints

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -4,7 +4,6 @@ import { URL } from 'url';
 import abslog from 'abslog';
 import * as schemas from '@podium/schemas';
 import * as utils from '@podium/utils';
-import Cache from 'ttl-mem-cache';
 import Proxy from 'http-proxy';
 
 export default class PodiumProxy {
@@ -21,7 +20,6 @@ export default class PodiumProxy {
         pathname = '/',
         prefix = '/podium-resource',
         timeout = 20000,
-        maxAge = Infinity,
         logger = null,
     } = {}) {
         this.#pathname = utils.pathnameBuilder(pathname);
@@ -48,32 +46,7 @@ export default class PodiumProxy {
             );
         });
 
-        this.#registry = new Cache({
-            ttl: maxAge,
-        });
-        this.#registry.on('error', (error) => {
-            this.#log.error(
-                'Error emitted by the registry in @podium/proxy module',
-                error,
-            );
-        });
-        this.#registry.on('set', (key, item) => {
-            Object.keys(item.proxy).forEach((name) => {
-                const path = utils.pathnameBuilder(
-                    this.#pathname,
-                    this.#prefix,
-                    key,
-                    name,
-                );
-                this.#log.debug(
-                    `a proxy endpoint is mounted at pathname: ${path} pointing to: ${item.proxy[name]}`,
-                );
-            });
-        });
-
-        this.#registry.on('dispose', (key) => {
-            this.#log.debug(`dispose proxy item on key "${key}"`);
-        });
+        this.#registry = new Map();
 
         this.#metrics = new Metrics();
         this.#metrics.on('error', (error) => {
@@ -120,7 +93,37 @@ export default class PodiumProxy {
                 'The value for the required argument "manifest" is not defined or not valid.',
             );
 
-        this.#registry.set(obj.name, obj, Infinity);
+        if (Array.isArray(obj.proxy)) {
+            obj.proxy.forEach((item) => {
+                this.#registry.set(`${obj.name}/${item.name}`, item.target);
+
+                const path = utils.pathnameBuilder(
+                    this.#pathname,
+                    this.#prefix,
+                    obj.name,
+                    item.name,
+                );
+                this.#log.debug(
+                    `a proxy endpoint is mounted at pathname: ${path} pointing to: ${item.target}`,
+                );
+            });
+        } else {
+            // NOTE: This can be removed when the object notation is removed from the schema
+            //       and the manifest only support an array for the proxy property.
+            Object.keys(obj.proxy).forEach((key) => {
+                this.#registry.set(`${obj.name}/${key}`, obj.proxy[key]);
+                
+                const path = utils.pathnameBuilder(
+                    this.#pathname,
+                    this.#prefix,
+                    obj.name,
+                    key,
+                );
+                this.#log.debug(
+                    `a proxy endpoint is mounted at pathname: ${path} pointing to: ${obj.proxy[key]}`,
+                );
+            });
+        }
     }
 
     process(incoming) {
@@ -155,23 +158,17 @@ export default class PodiumProxy {
                     params[key.name] = match[i];
                 }
 
-                // See if "podiumPodletName" matches a podlet in registry.
-                // If so we might want to proxy. If not, skip rest of processing
-                const manifest = this.#registry.get(params.podiumPodletName);
-                if (!manifest) {
+                const key = `${params.podiumPodletName}/${params.podiumProxyName}`;
+
+                // See if podlet has a matching proxy entry.
+                // If so we want to proxy. If not, skip rest of processing
+                if (!this.#registry.has(key)) {
                     endTimer({ labels: { podlet: params.podiumPodletName } });
                     resolve(incoming);
                     return;
                 }
 
-                // See if podlet has a matching proxy entry.
-                // If so we want to proxy. If not, skip rest of processing
-                let target = manifest.proxy[params.podiumProxyName];
-                if (!target) {
-                    endTimer({ labels: { podlet: params.podiumPodletName } });
-                    resolve(incoming);
-                    return;
-                }
+                let target = this.#registry.get(key);
 
                 // See if proxy entry is relative or not.
                 // In a layout server it will never be relative since the
@@ -257,14 +254,6 @@ export default class PodiumProxy {
             endTimer();
             resolve(incoming);
         });
-    }
-
-    dump() {
-        return this.#registry.dump();
-    }
-
-    load(dump) {
-        return this.#registry.load(dump);
     }
 
     get [Symbol.toStringTag]() {

--- a/package.json
+++ b/package.json
@@ -36,12 +36,11 @@
     },
     "dependencies": {
         "@metrics/client": "2.5.0",
-        "@podium/schemas": "5.0.0-next.4",
+        "@podium/schemas": "5.0.0-next.6",
         "@podium/utils": "5.0.0-next.6",
         "abslog": "2.4.0",
         "http-proxy": "1.18.1",
-        "path-to-regexp": "6.2.1",
-        "ttl-mem-cache": "4.1.0"
+        "path-to-regexp": "6.2.1"
     },
     "devDependencies": {
         "@semantic-release/changelog": "6.0.1",

--- a/tests/compatibility.js
+++ b/tests/compatibility.js
@@ -11,6 +11,10 @@ import { HttpIncoming } from '@podium/utils';
 import http from 'http';
 import Proxy from '../lib/proxy.js';
 
+// NOTE: This file can be removed when object notation on the proxy property is 
+//       removed from the schema and the manifest only support an array for the 
+//       proxy property.
+
 const reqFn = (req, res) => {
     res.statusCode = 200;
     res.setHeader('Content-Type', 'application/json');
@@ -112,9 +116,9 @@ tap.test('Proxying() - mount proxy on "/{pathname}/{prefix}/{manifestName}/{prox
     const proxy = new ProxyServer([
         {
             name: 'bar',
-            proxy: [
-                { name: 'a', target: `${serverAddr}/some/path` }
-            ],
+            proxy: {
+                a: `${serverAddr}/some/path`,
+            },
             version: '1.0.0',
             content: '/',
         },
@@ -146,9 +150,9 @@ tap.test('Proxying() - mount proxy on "/{pathname}/{prefix}/{manifestName}/{prox
     const proxy = new ProxyServer([
         {
             name: 'foo',
-            proxy: [
-                { name: 'b', target: `${serverAddr}/some/where/else` }
-            ],
+            proxy: {
+                b: `${serverAddr}/some/where/else`,
+            },
             version: '1.0.0',
             content: '/',
         },
@@ -180,17 +184,17 @@ tap.test('Proxying() - mount multiple proxies on "/{pathname}/{prefix}/{manifest
     const proxy = new ProxyServer([
         {
             name: 'bar',
-            proxy: [
-                { name: 'a', target: `${serverAddr}/some/path` }
-            ],
+            proxy: {
+                a: `${serverAddr}/some/path`,
+            },
             version: '1.0.0',
             content: '/',
         },
         {
             name: 'foo',
-            proxy: [
-                { name: 'b', target: `${serverAddr}/some/where/else` }
-            ],
+            proxy: {
+                b: `${serverAddr}/some/where/else`,
+            },
             version: '1.0.0',
             content: '/',
         },
@@ -232,9 +236,9 @@ tap.test('Proxying() - GET request with additional path values - should proxy to
     const proxy = new ProxyServer([
         {
             name: 'bar',
-            proxy: [
-                { name: 'a', target: `${serverAddr}/some/path` }
-            ],
+            proxy: {
+                a: `${serverAddr}/some/path`,
+            },
             version: '1.0.0',
             content: '/',
         },
@@ -266,9 +270,9 @@ tap.test('Proxying() - GET request with query params - should proxy query params
     const proxy = new ProxyServer([
         {
             name: 'bar',
-            proxy: [
-                { name: 'a', target: `${serverAddr}/some/path` }
-            ],
+            proxy: {
+                a: `${serverAddr}/some/path`,
+            },
             version: '1.0.0',
             content: '/',
         },
@@ -300,9 +304,9 @@ tap.test('Proxying() - POST request - should proxy query params to "{destination
     const proxy = new ProxyServer([
         {
             name: 'bar',
-            proxy: [
-                { name: 'a', target: `${serverAddr}/some/path` }
-            ],
+            proxy: {
+                a: `${serverAddr}/some/path`,
+            },
             version: '1.0.0',
             content: '/',
         },
@@ -329,7 +333,6 @@ tap.test('Proxying() - POST request - should proxy query params to "{destination
     t.end();
 });
 
-
 tap.test('Proxying() - metrics collection', async (t) => {
     const server = new HttpServer();
     server.request = reqFn;
@@ -340,17 +343,17 @@ tap.test('Proxying() - metrics collection', async (t) => {
         [
             {
                 name: 'foo',
-                proxy: [
-                    { name: 'a', target: '/foo' }
-                ],
+                proxy: {
+                    a: '/foo',
+                },
                 version: '1.0.0',
                 content: '/',
             },
             {
                 name: 'bar',
-                proxy: [
-                    { name: 'a', target: `${serverAddr}/some/path` }
-                ],
+                proxy: {
+                    a: `${serverAddr}/some/path`,
+                },
                 version: '1.0.0',
                 content: '/',
             },
@@ -412,9 +415,9 @@ tap.test('Proxying() - proxy to a non existing server - GET request will error -
     const proxy = new ProxyServer([
         {
             name: 'bar',
-            proxy: [
-                { name: 'a', target: `${serverAddr}/some/path` }
-            ],
+            proxy: {
+                a: `${serverAddr}/some/path`,
+            },
             version: '1.0.0',
             content: '/',
         },
@@ -453,9 +456,9 @@ tap.test('Proxying() - Trailer header - 400s when Trailer header is present', as
         [
             {
                 name: 'foo',
-                proxy: [
-                    { name: 'a', target: `${serverAddr}/some/path` }
-                ],
+                proxy: {
+                    a: `${serverAddr}/some/path`,
+                },
                 version: '1.0.0',
                 content: '/',
             },

--- a/tests/proxy.js
+++ b/tests/proxy.js
@@ -24,18 +24,3 @@ tap.test('.register() - invalid value given to "manifest" argument - should thro
     }, /The value for the required argument "manifest" is not defined or not valid./);
     t.end();
 });
-
-tap.test('.register() - valid value given to "manifest" argument - should set value in internal registry', (t) => {
-    const proxy = new Proxy();
-    proxy.register({
-        name: 'bar',
-        proxy: {
-            a: `/some/path`,
-        },
-        version: '1.0.0',
-        content: '/',
-    });
-    const result = proxy.dump();
-    t.equal(result[0][0], 'bar');
-    t.end();
-});


### PR DESCRIPTION
This adds support for manifest files providing an array of proxy endpoints. This PR is related to the same type of change in the client: https://github.com/podium-lib/client/pull/295

Almost all tests is duplicated to test that we support both the object notation to define proxy endpoints in the manifest and the new array of proxy endpoints.

Its also worth noting that we're removing the usage of the `ttl-mem-cache` module in favor of a plain `Map()`. The same should be applied to the client at one point (not urgent though). This will probably solve: https://github.com/podium-lib/issues/issues/38