### PR TITLE
fix: Add name to .register()

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ An options object containing configuration. The following values can be provided
 
 The Proxy instance havs the following API:
 
-### .register(manifest)
+### .register(name, manifest)
 
 Registers proxy target(s) by providing a Podium manifest.
 
@@ -97,7 +97,7 @@ import Proxy from '@podium/proxy';
 const proxy = new Proxy();
 
 // Register remote target(s) on separate namespace
-proxy.register({
+proxy.register('podlet-name-in-layout', {
     name: 'bar',
     proxy: {
         api: 'http://www.external.com/some/path',
@@ -106,6 +106,11 @@ proxy.register({
     content: '/bar',
 });
 ```
+
+#### name (required)
+
+Name for the registered podlet. This will be part of the URL to distinguish the
+podlets proxy endpoints in the URL space.
 
 #### manifest (required)
 

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -84,7 +84,12 @@ export default class PodiumProxy {
         return this.#registry;
     }
 
-    register(manifest = {}) {
+    register(name = '', manifest = {}) {
+        if (schemas.name(name).error)
+            throw new Error(
+                'The value for the required argument "name" is not defined or not valid.',
+            );
+
         // Do a stringify to hande that a @podium/podlet instance is passed in.
         const obj = JSON.parse(JSON.stringify(manifest));
 
@@ -95,12 +100,12 @@ export default class PodiumProxy {
 
         if (Array.isArray(obj.proxy)) {
             obj.proxy.forEach((item) => {
-                this.#registry.set(`${obj.name}/${item.name}`, item.target);
+                this.#registry.set(`${name}/${item.name}`, item.target);
 
                 const path = utils.pathnameBuilder(
                     this.#pathname,
                     this.#prefix,
-                    obj.name,
+                    name,
                     item.name,
                 );
                 this.#log.debug(
@@ -111,12 +116,12 @@ export default class PodiumProxy {
             // NOTE: This can be removed when the object notation is removed from the schema
             //       and the manifest only support an array for the proxy property.
             Object.keys(obj.proxy).forEach((key) => {
-                this.#registry.set(`${obj.name}/${key}`, obj.proxy[key]);
+                this.#registry.set(`${name}/${key}`, obj.proxy[key]);
                 
                 const path = utils.pathnameBuilder(
                     this.#pathname,
                     this.#prefix,
-                    obj.name,
+                    name,
                     key,
                 );
                 this.#log.debug(

--- a/tests/compatibility.js
+++ b/tests/compatibility.js
@@ -29,7 +29,7 @@ const reqFn = (req, res) => {
 
 /**
  * Proxy server utility
- * Spinns up a http server and attaches the proxy module
+ * Spins up a http server and attaches the proxy module
  */
 
 class ProxyServer {
@@ -42,8 +42,9 @@ class ProxyServer {
             prefix: 'proxy',
         });
 
-        manifests.forEach((manifest) => {
-            this.proxy.register(manifest);
+        manifests.forEach((arr) => {
+            const [ name, manifest ] = arr;
+            this.proxy.register(name, manifest);
         });
 
         this.app = http.createServer((req, res) => {
@@ -107,27 +108,27 @@ class ProxyServer {
     }
 }
 
-tap.test('Proxying() - mount proxy on "/{pathname}/{prefix}/{manifestName}/{proxyName}" - GET request - should proxy to "{destination}/some/path"', async (t) => {
+tap.test('Proxying() - mount proxy on "/{localLayoutPathname}/{proxyPrefixName}/{localPodletName}/{podletProxyTargetName}" - GET request - should proxy to "{destination}/some/path"', async (t) => {
     const server = new HttpServer();
     server.request = reqFn;
 
     const serverAddr = await server.listen();
 
     const proxy = new ProxyServer([
-        {
+        ['local-podlet-name', {
             name: 'bar',
             proxy: {
                 a: `${serverAddr}/some/path`,
             },
             version: '1.0.0',
             content: '/',
-        },
+        }],
     ]);
     const proxyAddr = await proxy.listen();
 
     const { body } = await request({
         address: proxyAddr,
-        pathname: '/layout/proxy/bar/a',
+        pathname: '/layout/proxy/local-podlet-name/a',
         json: true,
     });
 
@@ -141,27 +142,27 @@ tap.test('Proxying() - mount proxy on "/{pathname}/{prefix}/{manifestName}/{prox
     t.end();
 });
 
-tap.test('Proxying() - mount proxy on "/{pathname}/{prefix}/{manifestName}/{proxyName}" - GET request - should proxy to "{destination}/some/where/else"', async (t) => {
+tap.test('Proxying() - mount proxy on "/{localLayoutPathname}/{proxyPrefixName}/{localPodletName}/{podletProxyTargetName}" - GET request - should proxy to "{destination}/some/where/else"', async (t) => {
     const server = new HttpServer();
     server.request = reqFn;
 
     const serverAddr = await server.listen();
 
     const proxy = new ProxyServer([
-        {
+        ['local-podlet-name', {
             name: 'foo',
             proxy: {
                 b: `${serverAddr}/some/where/else`,
             },
             version: '1.0.0',
             content: '/',
-        },
+        }],
     ]);
     const proxyAddr = await proxy.listen();
 
     const { body } = await request({
         address: proxyAddr,
-        pathname: '/layout/proxy/foo/b',
+        pathname: '/layout/proxy/local-podlet-name/b',
         json: true,
     });
 
@@ -175,35 +176,35 @@ tap.test('Proxying() - mount proxy on "/{pathname}/{prefix}/{manifestName}/{prox
     t.end();
 });
 
-tap.test('Proxying() - mount multiple proxies on "/{pathname}/{prefix}/{manifestName}/{proxyName}" - GET request - should proxy to destinations', async (t) => {
+tap.test('Proxying() - mount multiple proxies on "/{localLayoutPathname}/{proxyPrefixName}/{localPodletName}/{podletProxyTargetName}" - GET request - should proxy to destinations', async (t) => {
     const server = new HttpServer();
     server.request = reqFn;
 
     const serverAddr = await server.listen();
 
     const proxy = new ProxyServer([
-        {
+        ['local-podlet-name-bar', {
             name: 'bar',
             proxy: {
                 a: `${serverAddr}/some/path`,
             },
             version: '1.0.0',
             content: '/',
-        },
-        {
+        }],
+        ['local-podlet-name-foo', {
             name: 'foo',
             proxy: {
                 b: `${serverAddr}/some/where/else`,
             },
             version: '1.0.0',
             content: '/',
-        },
+        }],
     ]);
     const proxyAddr = await proxy.listen();
 
     const resultA = await request({
         address: proxyAddr,
-        pathname: '/layout/proxy/bar/a',
+        pathname: '/layout/proxy/local-podlet-name-bar/a',
         json: true,
     });
 
@@ -213,7 +214,7 @@ tap.test('Proxying() - mount multiple proxies on "/{pathname}/{prefix}/{manifest
 
     const resultB = await request({
         address: proxyAddr,
-        pathname: '/layout/proxy/foo/b',
+        pathname: '/layout/proxy/local-podlet-name-foo/b',
         json: true,
     });
 
@@ -227,6 +228,7 @@ tap.test('Proxying() - mount multiple proxies on "/{pathname}/{prefix}/{manifest
     t.end();
 });
 
+
 tap.test('Proxying() - GET request with additional path values - should proxy to "{destination}/some/path/extra?foo=bar"', async (t) => {
     const server = new HttpServer();
     server.request = reqFn;
@@ -234,20 +236,20 @@ tap.test('Proxying() - GET request with additional path values - should proxy to
     const serverAddr = await server.listen();
 
     const proxy = new ProxyServer([
-        {
+        ['local-podlet-name', {
             name: 'bar',
             proxy: {
                 a: `${serverAddr}/some/path`,
             },
             version: '1.0.0',
             content: '/',
-        },
+        }],
     ]);
     const proxyAddr = await proxy.listen();
 
     const { body } = await request({
         address: proxyAddr,
-        pathname: '/layout/proxy/bar/a/extra?foo=bar',
+        pathname: '/layout/proxy/local-podlet-name/a/extra?foo=bar',
         json: true,
     });
 
@@ -268,20 +270,20 @@ tap.test('Proxying() - GET request with query params - should proxy query params
     const serverAddr = await server.listen();
 
     const proxy = new ProxyServer([
-        {
+        ['local-podlet-name', {
             name: 'bar',
             proxy: {
                 a: `${serverAddr}/some/path`,
             },
             version: '1.0.0',
             content: '/',
-        },
+        }],
     ]);
     const proxyAddr = await proxy.listen();
 
     const { body } = await request({
         address: proxyAddr,
-        pathname: '/layout/proxy/bar/a?foo=bar',
+        pathname: '/layout/proxy/local-podlet-name/a?foo=bar',
         json: true,
     });
 
@@ -302,21 +304,21 @@ tap.test('Proxying() - POST request - should proxy query params to "{destination
     const serverAddr = await server.listen();
 
     const proxy = new ProxyServer([
-        {
+        ['local-podlet-name', {
             name: 'bar',
             proxy: {
                 a: `${serverAddr}/some/path`,
             },
             version: '1.0.0',
             content: '/',
-        },
+        }],
     ]);
     const proxyAddr = await proxy.listen();
 
     const { body } = await request(
         {
             address: proxyAddr,
-            pathname: '/layout/proxy/bar/a',
+            pathname: '/layout/proxy/local-podlet-name/a',
             method: 'POST',
             json: true,
         },
@@ -341,22 +343,22 @@ tap.test('Proxying() - metrics collection', async (t) => {
 
     const proxy = new ProxyServer(
         [
-            {
+            ['local-podlet-name-foo', {
                 name: 'foo',
                 proxy: {
                     a: '/foo',
                 },
                 version: '1.0.0',
                 content: '/',
-            },
-            {
+            }],
+            ['local-podlet-name-bar', {
                 name: 'bar',
                 proxy: {
                     a: `${serverAddr}/some/path`,
                 },
                 version: '1.0.0',
                 content: '/',
-            },
+            }],
         ],
         { name: 'mylayout' },
     );
@@ -398,8 +400,8 @@ tap.test('Proxying() - metrics collection', async (t) => {
 
     const proxyAddr = await proxy.listen();
 
-    await request({ address: proxyAddr, pathname: '/layout/proxy/foo/a' });
-    await request({ address: proxyAddr, pathname: '/layout/proxy/bar/a' });
+    await request({ address: proxyAddr, pathname: '/layout/proxy/local-podlet-name-foo/a' });
+    await request({ address: proxyAddr, pathname: '/layout/proxy/local-podlet-name-bar/a' });
 
     proxy.proxy.metrics.push(null);
 
@@ -413,15 +415,17 @@ tap.test('Proxying() - proxy to a non existing server - GET request will error -
     const serverAddr = 'http://0.0.0.0:9854';
 
     const proxy = new ProxyServer([
-        {
+        ['local-podlet-name', {
             name: 'bar',
             proxy: {
                 a: `${serverAddr}/some/path`,
             },
             version: '1.0.0',
             content: '/',
-        },
-    ]);
+        }],
+    ],         
+    { name: 'mylayout' });
+
     const proxyAddr = await proxy.listen();
 
     proxy.proxy.metrics.pipe(
@@ -430,15 +434,15 @@ tap.test('Proxying() - proxy to a non existing server - GET request will error -
             t.equal(arr[0].name, 'podium_proxy_process');
             t.equal(arr[0].type, 5);
             t.match(arr[0].labels, [
-                { name: 'name', value: '' },
-                { name: 'podlet', value: 'bar' },
+                { name: 'name', value: 'mylayout' },
+                { name: 'podlet', value: 'local-podlet-name' },
                 { name: 'proxy', value: true },
                 { name: 'error', value: true },
             ]);
         }),
     );
 
-    await request({ address: proxyAddr, pathname: '/layout/proxy/bar/a' });
+    await request({ address: proxyAddr, pathname: '/layout/proxy/local-podlet-name/a' });
 
     proxy.proxy.metrics.push(null);
 
@@ -454,14 +458,14 @@ tap.test('Proxying() - Trailer header - 400s when Trailer header is present', as
 
     const proxy = new ProxyServer(
         [
-            {
+            ['local-podlet-name', {
                 name: 'foo',
                 proxy: {
                     a: `${serverAddr}/some/path`,
                 },
                 version: '1.0.0',
                 content: '/',
-            },
+            }],
         ],
         { name: 'mylayout' },
     );
@@ -470,7 +474,7 @@ tap.test('Proxying() - Trailer header - 400s when Trailer header is present', as
 
     const { stdout } = await new Promise((resolve, reject) => {
         exec(
-            `curl -i -H 'Trailer: Krynos' -H 'User-Agent: Mozilla' '${proxyAddr}/layout/proxy/foo/a'`,
+            `curl -i -H 'Trailer: Krynos' -H 'User-Agent: Mozilla' '${proxyAddr}/layout/proxy/local-podlet-name/a'`,
             (error, stdoutput, stderror) => {
                 if (error) {
                     reject(error);

--- a/tests/proxy.js
+++ b/tests/proxy.js
@@ -7,11 +7,29 @@ tap.test('Proxy() - object tag - should be PodiumProxy', (t) => {
     t.end();
 });
 
+tap.test('.register() - no value given to "name" argument - should throw', (t) => {
+    t.plan(1);
+    const proxy = new Proxy();
+    t.throws(() => {
+        proxy.register();
+    }, /The value for the required argument "name" is not defined or not valid./);
+    t.end();
+});
+
+tap.test('.register() - invalid value given to "name" argument - should throw', (t) => {
+    t.plan(1);
+    const proxy = new Proxy();
+    t.throws(() => {
+        proxy.register('æøå - tada');
+    }, /The value for the required argument "name" is not defined or not valid./);
+    t.end();
+});
+
 tap.test('.register() - no value given to "manifest" argument - should throw', (t) => {
     t.plan(1);
     const proxy = new Proxy();
     t.throws(() => {
-        proxy.register(); // eslint-disable-line no-unused-vars
+        proxy.register('local-podlet-name');
     }, /The value for the required argument "manifest" is not defined or not valid./);
     t.end();
 });
@@ -20,7 +38,7 @@ tap.test('.register() - invalid value given to "manifest" argument - should thro
     t.plan(1);
     const proxy = new Proxy();
     t.throws(() => {
-        proxy.register({ foo: 'bar', name: 'æøå - tada' }); // eslint-disable-line no-unused-vars
+        proxy.register('local-podlet-name', { foo: 'bar', name: 'æøå - tada' });
     }, /The value for the required argument "manifest" is not defined or not valid./);
     t.end();
 });

--- a/tests/proxying.js
+++ b/tests/proxying.js
@@ -25,7 +25,7 @@ const reqFn = (req, res) => {
 
 /**
  * Proxy server utility
- * Spinns up a http server and attaches the proxy module
+ * Spins up a http server and attaches the proxy module
  */
 
 class ProxyServer {
@@ -38,8 +38,9 @@ class ProxyServer {
             prefix: 'proxy',
         });
 
-        manifests.forEach((manifest) => {
-            this.proxy.register(manifest);
+        manifests.forEach((arr) => {
+            const [ name, manifest ] = arr;
+            this.proxy.register(name, manifest);
         });
 
         this.app = http.createServer((req, res) => {
@@ -103,27 +104,27 @@ class ProxyServer {
     }
 }
 
-tap.test('Proxying() - mount proxy on "/{pathname}/{prefix}/{manifestName}/{proxyName}" - GET request - should proxy to "{destination}/some/path"', async (t) => {
+tap.test('Proxying() - mount proxy on "/{localLayoutPathname}/{proxyPrefixName}/{localPodletName}/{podletProxyTargetName}" - GET request - should proxy to "{destination}/some/path"', async (t) => {
     const server = new HttpServer();
     server.request = reqFn;
 
     const serverAddr = await server.listen();
 
     const proxy = new ProxyServer([
-        {
+        ['local-podlet-name', {
             name: 'bar',
             proxy: [
                 { name: 'a', target: `${serverAddr}/some/path` }
             ],
             version: '1.0.0',
             content: '/',
-        },
+        }],
     ]);
     const proxyAddr = await proxy.listen();
 
     const { body } = await request({
         address: proxyAddr,
-        pathname: '/layout/proxy/bar/a',
+        pathname: '/layout/proxy/local-podlet-name/a',
         json: true,
     });
 
@@ -137,27 +138,27 @@ tap.test('Proxying() - mount proxy on "/{pathname}/{prefix}/{manifestName}/{prox
     t.end();
 });
 
-tap.test('Proxying() - mount proxy on "/{pathname}/{prefix}/{manifestName}/{proxyName}" - GET request - should proxy to "{destination}/some/where/else"', async (t) => {
+tap.test('Proxying() - mount proxy on "/{localLayoutPathname}/{proxyPrefixName}/{localPodletName}/{podletProxyTargetName}" - GET request - should proxy to "{destination}/some/where/else"', async (t) => {
     const server = new HttpServer();
     server.request = reqFn;
 
     const serverAddr = await server.listen();
 
     const proxy = new ProxyServer([
-        {
+        ['local-podlet-name', {
             name: 'foo',
             proxy: [
                 { name: 'b', target: `${serverAddr}/some/where/else` }
             ],
             version: '1.0.0',
             content: '/',
-        },
+        }],
     ]);
     const proxyAddr = await proxy.listen();
 
     const { body } = await request({
         address: proxyAddr,
-        pathname: '/layout/proxy/foo/b',
+        pathname: '/layout/proxy/local-podlet-name/b',
         json: true,
     });
 
@@ -171,35 +172,35 @@ tap.test('Proxying() - mount proxy on "/{pathname}/{prefix}/{manifestName}/{prox
     t.end();
 });
 
-tap.test('Proxying() - mount multiple proxies on "/{pathname}/{prefix}/{manifestName}/{proxyName}" - GET request - should proxy to destinations', async (t) => {
+tap.test('Proxying() - mount multiple proxies on "/{localLayoutPathname}/{proxyPrefixName}/{localPodletName}/{podletProxyTargetName}" - GET request - should proxy to destinations', async (t) => {
     const server = new HttpServer();
     server.request = reqFn;
 
     const serverAddr = await server.listen();
 
     const proxy = new ProxyServer([
-        {
+        ['local-podlet-name-bar', {
             name: 'bar',
             proxy: [
                 { name: 'a', target: `${serverAddr}/some/path` }
             ],
             version: '1.0.0',
             content: '/',
-        },
-        {
+        }],
+        ['local-podlet-name-foo', {
             name: 'foo',
             proxy: [
                 { name: 'b', target: `${serverAddr}/some/where/else` }
             ],
             version: '1.0.0',
             content: '/',
-        },
+        }],
     ]);
     const proxyAddr = await proxy.listen();
-
+    
     const resultA = await request({
         address: proxyAddr,
-        pathname: '/layout/proxy/bar/a',
+        pathname: '/layout/proxy/local-podlet-name-bar/a',
         json: true,
     });
 
@@ -209,7 +210,7 @@ tap.test('Proxying() - mount multiple proxies on "/{pathname}/{prefix}/{manifest
 
     const resultB = await request({
         address: proxyAddr,
-        pathname: '/layout/proxy/foo/b',
+        pathname: '/layout/proxy/local-podlet-name-foo/b',
         json: true,
     });
 
@@ -230,20 +231,20 @@ tap.test('Proxying() - GET request with additional path values - should proxy to
     const serverAddr = await server.listen();
 
     const proxy = new ProxyServer([
-        {
+        ['local-podlet-name', {
             name: 'bar',
             proxy: [
                 { name: 'a', target: `${serverAddr}/some/path` }
             ],
             version: '1.0.0',
             content: '/',
-        },
+        }],
     ]);
     const proxyAddr = await proxy.listen();
 
     const { body } = await request({
         address: proxyAddr,
-        pathname: '/layout/proxy/bar/a/extra?foo=bar',
+        pathname: '/layout/proxy/local-podlet-name/a/extra?foo=bar',
         json: true,
     });
 
@@ -264,20 +265,20 @@ tap.test('Proxying() - GET request with query params - should proxy query params
     const serverAddr = await server.listen();
 
     const proxy = new ProxyServer([
-        {
+        ['local-podlet-name', {
             name: 'bar',
             proxy: [
                 { name: 'a', target: `${serverAddr}/some/path` }
             ],
             version: '1.0.0',
             content: '/',
-        },
+        }],
     ]);
     const proxyAddr = await proxy.listen();
 
     const { body } = await request({
         address: proxyAddr,
-        pathname: '/layout/proxy/bar/a?foo=bar',
+        pathname: '/layout/proxy/local-podlet-name/a?foo=bar',
         json: true,
     });
 
@@ -298,21 +299,21 @@ tap.test('Proxying() - POST request - should proxy query params to "{destination
     const serverAddr = await server.listen();
 
     const proxy = new ProxyServer([
-        {
+        ['local-podlet-name', {
             name: 'bar',
             proxy: [
                 { name: 'a', target: `${serverAddr}/some/path` }
             ],
             version: '1.0.0',
             content: '/',
-        },
+        }],
     ]);
     const proxyAddr = await proxy.listen();
 
     const { body } = await request(
         {
             address: proxyAddr,
-            pathname: '/layout/proxy/bar/a',
+            pathname: '/layout/proxy/local-podlet-name/a',
             method: 'POST',
             json: true,
         },
@@ -329,7 +330,6 @@ tap.test('Proxying() - POST request - should proxy query params to "{destination
     t.end();
 });
 
-
 tap.test('Proxying() - metrics collection', async (t) => {
     const server = new HttpServer();
     server.request = reqFn;
@@ -338,22 +338,22 @@ tap.test('Proxying() - metrics collection', async (t) => {
 
     const proxy = new ProxyServer(
         [
-            {
+            ['local-podlet-name-foo', {
                 name: 'foo',
                 proxy: [
                     { name: 'a', target: '/foo' }
                 ],
                 version: '1.0.0',
                 content: '/',
-            },
-            {
+            }],
+            ['local-podlet-name-bar', {
                 name: 'bar',
                 proxy: [
                     { name: 'a', target: `${serverAddr}/some/path` }
                 ],
                 version: '1.0.0',
                 content: '/',
-            },
+            }],
         ],
         { name: 'mylayout' },
     );
@@ -395,8 +395,8 @@ tap.test('Proxying() - metrics collection', async (t) => {
 
     const proxyAddr = await proxy.listen();
 
-    await request({ address: proxyAddr, pathname: '/layout/proxy/foo/a' });
-    await request({ address: proxyAddr, pathname: '/layout/proxy/bar/a' });
+    await request({ address: proxyAddr, pathname: '/layout/proxy/local-podlet-name-foo/a' });
+    await request({ address: proxyAddr, pathname: '/layout/proxy/local-podlet-name-bar/a' });
 
     proxy.proxy.metrics.push(null);
 
@@ -410,15 +410,15 @@ tap.test('Proxying() - proxy to a non existing server - GET request will error -
     const serverAddr = 'http://0.0.0.0:9854';
 
     const proxy = new ProxyServer([
-        {
+        ['local-podlet-name', {
             name: 'bar',
             proxy: [
                 { name: 'a', target: `${serverAddr}/some/path` }
             ],
             version: '1.0.0',
             content: '/',
-        },
-    ]);
+        }],
+    ], { name: 'mylayout' });
     const proxyAddr = await proxy.listen();
 
     proxy.proxy.metrics.pipe(
@@ -427,15 +427,15 @@ tap.test('Proxying() - proxy to a non existing server - GET request will error -
             t.equal(arr[0].name, 'podium_proxy_process');
             t.equal(arr[0].type, 5);
             t.match(arr[0].labels, [
-                { name: 'name', value: '' },
-                { name: 'podlet', value: 'bar' },
+                { name: 'name', value: 'mylayout' },
+                { name: 'podlet', value: 'local-podlet-name' },
                 { name: 'proxy', value: true },
                 { name: 'error', value: true },
             ]);
         }),
     );
 
-    await request({ address: proxyAddr, pathname: '/layout/proxy/bar/a' });
+    await request({ address: proxyAddr, pathname: '/layout/proxy/local-podlet-name/a' });
 
     proxy.proxy.metrics.push(null);
 
@@ -451,14 +451,14 @@ tap.test('Proxying() - Trailer header - 400s when Trailer header is present', as
 
     const proxy = new ProxyServer(
         [
-            {
+            ['local-podlet-name', {
                 name: 'foo',
                 proxy: [
                     { name: 'a', target: `${serverAddr}/some/path` }
                 ],
                 version: '1.0.0',
                 content: '/',
-            },
+            }],
         ],
         { name: 'mylayout' },
     );
@@ -467,7 +467,7 @@ tap.test('Proxying() - Trailer header - 400s when Trailer header is present', as
 
     const { stdout } = await new Promise((resolve, reject) => {
         exec(
-            `curl -i -H 'Trailer: Krynos' -H 'User-Agent: Mozilla' '${proxyAddr}/layout/proxy/foo/a'`,
+            `curl -i -H 'Trailer: Krynos' -H 'User-Agent: Mozilla' '${proxyAddr}/layout/proxy/local-podlet-name/a'`,
             (error, stdoutput, stderror) => {
                 if (error) {
                     reject(error);


### PR DESCRIPTION
This adds a `name` argument to the `.register()` method which is used to register podlets in the proxy. By this its possible to set the `name` which a podlet is registered on in the registry holding the proxy endpoints internally. This `name` are again reflected in the URL space we register proxy endpoints on.

In ex a layout the value for `name` will be the `name` one register a podlet with in the layout. This is needed to avoid naming conflicts in the URL when mounting proxy endpoints. We can not pick this from the podlets manifest since we can not trust that podlets have unique names so we need to use the name for the podlet when registering a podlet in a layout.

This is part of solving: https://github.com/podium-lib/layout/pull/451