### PR TITLE
fix: update podium/node-http-proxy to remove deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@metrics/client": "2.5.3",
-    "@podium/node-http-proxy": "1.20.0",
+    "@podium/node-http-proxy": "1.20.1",
     "@podium/schemas": "5.0.6",
     "@podium/utils": "5.3.1",
     "abslog": "2.4.4",


### PR DESCRIPTION
https://github.com/podium-lib/node-http-proxy-fork/pull/1